### PR TITLE
schedule start time based on last block time

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -679,15 +679,13 @@ func (cs *State) updateToState(state sm.State) {
 	cs.updateHeight(height)
 	cs.updateRoundStep(0, cstypes.RoundStepNewHeight)
 
-	if cs.CommitTime.IsZero() {
+	if state.LastBlockTime.IsZero() {
 		// "Now" makes it easier to sync up dev nodes.
 		// We add timeoutCommit to allow transactions
 		// to be gathered for the first block.
-		// And alternative solution that relies on clocks:
-		// cs.StartTime = state.LastBlockTime.Add(timeoutCommit)
 		cs.StartTime = cs.config.Commit(tmtime.Now())
 	} else {
-		cs.StartTime = cs.config.Commit(cs.CommitTime)
+		cs.StartTime = cs.config.Commit(state.LastBlockTime)
 	}
 
 	cs.Validators = validators


### PR DESCRIPTION
Previously the new block `startTime` is set to `commitTime + timeoutCommit`,  which means that the next block time will be at least `timeoutCommit` seconds after the previous block was committed. 
This PR propose a new `startTime` schedule solution, that we set this value to `lastBlockTime + timeoutCommit`, so that the block interval would be `timeoutCommit` at positive case. 
And if the block execution take too much time, we can immediately start a new block, instead of waiting the extra  time of `timeoutCommit`. The extra waiting time seems not necessary as the previous block execution time is enough for txpool to accept enough transactions to be sealed in the next block. 