### PR TITLE
feat: SequencerHA interface + StateV2 dynamic block interval

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -123,8 +123,9 @@ func DefaultNewNode(config *cfg.Config, logger log.Logger) (*Node, error) {
 		DefaultDBProvider,
 		DefaultMetricsProvider(config.Instrumentation),
 		logger,
-		nil,
-		nil,
+		nil, // sequencerVerifier
+		nil, // sequencerSigner
+		nil, // ha: no HA in default node
 	)
 }
 
@@ -250,6 +251,8 @@ type Node struct {
 	// Sequencer mode (after upgrade)
 	stateV2               *sequencer.StateV2
 	blockBroadcastReactor *sequencer.BlockBroadcastReactor
+	sigStore              *sequencer.SignatureStore
+	ha                    sequencer.SequencerHA
 }
 
 func initDBs(config *cfg.Config, dbProvider DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, sigStore *sequencer.SignatureStore, err error) {
@@ -523,7 +526,6 @@ func createSequencerComponents(
 	// Create StateV2
 	stateV2, err := sequencer.NewStateV2(
 		l2Node,
-		sequencer.DefaultBlockInterval,
 		logger,
 		verifier,
 		signer,
@@ -798,6 +800,7 @@ func NewNode(
 	logger log.Logger,
 	sequencerVerifier sequencer.SequencerVerifier,
 	sequencerSigner sequencer.Signer,
+	ha sequencer.SequencerHA,
 	options ...Option,
 ) (
 	*Node, error,
@@ -1014,6 +1017,8 @@ func NewNode(
 		indexerService:   indexerService,
 		blockIndexer:     blockIndexer,
 		eventBus:         eventBus,
+		sigStore:         sigStore,
+		ha:               ha,
 	}
 	node.BaseService = *service.NewBaseService(logger, "Node", node)
 
@@ -1030,9 +1035,14 @@ func NewNode(
 			sequencerVerifier,
 			sequencerSigner,
 			sigStore,
-			nil, // ha: nil for now, Raft HA will be injected in a future milestone
+			ha, // HA service injected from NewNode caller; nil disables HA mode
 		); err != nil {
 			return nil, err
+		}
+
+		// Wire HA FSM callback: ApplyBlock handles geth apply + SaveSignature.
+		if ha != nil {
+			ha.SetOnBlockApplied(node.stateV2.ApplyBlock)
 		}
 
 		// Set stateV2&verifier&sigStore on blocksync reactor for post-upgrade

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -185,6 +185,9 @@ func NewTendermint(app abci.Application, opts *Options) *nm.Node {
 		nm.DefaultDBProvider,
 		nm.DefaultMetricsProvider(config.Instrumentation),
 		logger,
+		nil, // sequencerVerifier
+		nil, // sequencerSigner
+		nil, // ha: no HA in RPC test node
 	)
 	if err != nil {
 		panic(err)

--- a/sequencer/block_cache_test.go
+++ b/sequencer/block_cache_test.go
@@ -239,17 +239,12 @@ func TestBlockRingBuffer_RollbackTo_All(t *testing.T) {
 		rb.Add(makeBlock(i, byte(i)))
 	}
 
-	// Rollback to before first block
+	// Rollback to before first block — removes all blocks with h > 99
 	rb.RollbackTo(99)
 
-	// All blocks removed, but minHeight stays at 100
-	// (rollbackTo only removes > targetHeight)
-	assert.Equal(t, 1, rb.Count()) // Block 100 remains (not > 99, it's == 100)
-
-	// Actually let's re-read the logic... rollbackTo removes h > targetHeight
-	// So rollbackTo(99) removes 100, 101, 102, 103, 104
-	// Wait, the loop is: for h := rb.maxHeight; h > targetHeight; h--
-	// So it removes 104, 103, 102, 101, 100 (all > 99)
+	// rollbackTo loop: for h := rb.maxHeight; h > targetHeight; h--
+	// removes 104, 103, 102, 101, 100 (all > 99)
+	assert.Equal(t, 0, rb.Count())
 }
 
 func TestBlockRingBuffer_RollbackTo_All_Correct(t *testing.T) {

--- a/sequencer/broadcast_reactor.go
+++ b/sequencer/broadcast_reactor.go
@@ -267,12 +267,13 @@ func (r *BlockBroadcastReactor) broadcastRoutine() {
 		case <-r.Quit():
 			return
 		case block := <-source:
-			// HA Follower: consume channel but do not broadcast.
-			// When promoted to Leader, the next block automatically starts broadcasting.
+			// Always populate recentBlocks so the cache is warm if this follower
+			// is promoted to leader and starts serving block requests from fullnodes.
+			r.recentBlocks.Add(block)
+			// HA Follower: do not broadcast, only drain the channel.
 			if r.stateV2.IsHAMode() && !r.stateV2.IsHALeader() {
 				continue
 			}
-			r.recentBlocks.Add(block)
 			r.broadcast(block)
 		}
 	}
@@ -478,14 +479,9 @@ func (r *BlockBroadcastReactor) applyBlock(block *BlockV2) error {
 		return fmt.Errorf("parent mismatch")
 	}
 
-	// Update state via stateV2 (unified entry point)
+	// ApplyBlock handles geth apply + SaveSignature in one call.
 	if err := r.stateV2.ApplyBlock(block); err != nil {
 		return err
-	}
-
-	// Persist signature for historical block serving
-	if err := r.sigStore.SaveSignature(block.Hash, block.Signature); err != nil {
-		panic(fmt.Sprintf("failed to save signature at height %d: %v", block.Number, err))
 	}
 
 	// Add to recent blocks

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -34,6 +34,17 @@ type Signer interface {
 // SequencerHA is the abstraction for Raft HA cluster.
 // In single-node mode, ha == nil and all HA-related logic is skipped.
 type SequencerHA interface {
+	// Start initializes and starts the Raft service.
+	// leader (bootstrap=true): starts as a single-node cluster, immediately becomes Leader.
+	// follower (bootstrap=false): initializes Raft, then asynchronously retries Join() in the
+	//   background until it successfully joins the cluster or the service is stopped.
+	// Called by StateV2.OnStart() when the upgrade height is reached.
+	Start() error
+
+	// Stop gracefully shuts down the Raft service.
+	// Called by StateV2.OnStop() when the upgrade height has been passed.
+	Stop()
+
 	// IsLeader returns whether the current node is the Raft leader (sole block producer).
 	IsLeader() bool
 
@@ -52,4 +63,9 @@ type SequencerHA interface {
 	// Subscribe returns a channel that delivers blocks after Raft commit.
 	// Both leader and follower subscribe; used by broadcastRoutine for P2P broadcast.
 	Subscribe() <-chan *BlockV2
+
+	// SetOnBlockApplied registers the callback invoked by the Raft FSM on every
+	// committed log entry. The callback should execute ApplyBlock + SaveSignature.
+	// Must be called before Start().
+	SetOnBlockApplied(fn func(*BlockV2) error)
 }

--- a/sequencer/state_v2.go
+++ b/sequencer/state_v2.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	// DefaultBlockInterval is the default interval between blocks
-	// TODO: make this configurable
-	DefaultBlockInterval = 3000 * time.Millisecond
+	// BlockInterval is the fallback interval for empty blocks (no txs).
+	BlockInterval = 3000 * time.Millisecond
+	// FastBlockInterval is the txpool polling interval.
+	// When pending txs are found, a block is produced immediately.
+	FastBlockInterval = 300 * time.Millisecond
 )
 
 // StateV2 manages the state for centralized sequencer mode.
@@ -41,7 +43,8 @@ type StateV2 struct {
 	logger   log.Logger
 
 	// Block production
-	blockInterval time.Duration
+	blockInterval     time.Duration // empty-block fallback interval (default 3s)
+	fastBlockInterval time.Duration // txpool polling interval (default 300ms)
 
 	// Broadcast channel - non-HA self-produced blocks are sent here
 	broadcastCh chan *BlockV2
@@ -55,7 +58,6 @@ type StateV2 struct {
 // verifier is required when signer is configured (sequencer/HA nodes must verify blocks).
 func NewStateV2(
 	l2Node l2node.L2Node,
-	blockInterval time.Duration,
 	logger log.Logger,
 	verifier SequencerVerifier,
 	signer Signer,
@@ -65,20 +67,18 @@ func NewStateV2(
 	if verifier == nil {
 		return nil, fmt.Errorf("sequencer verifier is required for V2 mode")
 	}
-	if blockInterval <= 0 {
-		blockInterval = DefaultBlockInterval
-	}
 
 	s := &StateV2{
-		l2Node:        l2Node,
-		signer:        signer,
-		verifier:      verifier,
-		sigStore:      sigStore,
-		ha:            ha,
-		blockInterval: blockInterval,
-		logger:        logger.With("module", "stateV2"),
-		broadcastCh:   make(chan *BlockV2, 100),
-		quitCh:        make(chan struct{}),
+		l2Node:            l2Node,
+		signer:            signer,
+		verifier:          verifier,
+		sigStore:          sigStore,
+		ha:                ha,
+		blockInterval:     BlockInterval,
+		fastBlockInterval: FastBlockInterval,
+		logger:            logger.With("module", "stateV2"),
+		broadcastCh:       make(chan *BlockV2, 100),
+		quitCh:            make(chan struct{}),
 	}
 
 	s.BaseService = *service.NewBaseService(logger, "StateV2", s)
@@ -105,6 +105,14 @@ func (s *StateV2) OnStart() error {
 		"hasSigner", s.signer != nil,
 		"isHAMode", s.ha != nil)
 
+	// Start HA service at upgrade height. This initializes Raft and begins
+	// leader election (bootstrap) or cluster join (follower).
+	if s.ha != nil {
+		if err := s.ha.Start(); err != nil {
+			return fmt.Errorf("failed to start HA service: %w", err)
+		}
+	}
+
 	// Fullnode (no signer) does not produce blocks; applyRoutine is managed by the reactor.
 	// Nodes with signer start roleCheckRoutine, which handles dynamic role detection.
 	if s.signer != nil {
@@ -118,30 +126,73 @@ func (s *StateV2) OnStart() error {
 func (s *StateV2) OnStop() {
 	s.logger.Info("Stopping StateV2")
 	close(s.quitCh)
+	if s.ha != nil {
+		s.ha.Stop()
+	}
 }
 
 // roleCheckRoutine is the unified loop for role detection and block production.
 // It runs for all nodes with a signer (ActiveSequencer, HA-Leader, HA-Follower).
-// On each tick it checks isActiveSequencer(): if true, produces a block; otherwise idles.
-// This enables bidirectional role transitions without restarting the service.
+//
+// Two timers drive block production:
+//   - fastTicker (300ms): polls txpool via assembleBlock; produces immediately when txs found.
+//   - slowTimer (3s): forces a block (even empty) to maintain chain liveness.
+//
+// When fastTicker produces a block, slowTimer is reset to avoid redundant empty blocks.
 func (s *StateV2) roleCheckRoutine() {
-	ticker := time.NewTicker(s.blockInterval)
-	defer ticker.Stop()
+	fastTicker := time.NewTicker(s.fastBlockInterval)
+	slowTimer := time.NewTimer(s.blockInterval)
+	defer fastTicker.Stop()
+	defer slowTimer.Stop()
 
-	s.logger.Info("Starting role check routine", "interval", s.blockInterval)
+	s.logger.Info("Starting role check routine",
+		"pollInterval", s.fastBlockInterval,
+		"emptyBlockInterval", s.blockInterval)
 
 	for {
 		select {
 		case <-s.quitCh:
 			s.logger.Info("Role check routine stopped")
 			return
-		case <-ticker.C:
+
+		case <-fastTicker.C:
 			if !s.isActiveSequencer() {
 				continue
 			}
-			s.produceBlock()
+			block, collectedL1Msgs, err := s.assembleBlock()
+			if err != nil {
+				continue
+			}
+			if len(block.Transactions) == 0 && !collectedL1Msgs {
+				continue // empty block, discard and wait for next tick
+			}
+			s.commitBlock(block, collectedL1Msgs)
+			resetTimer(slowTimer, s.blockInterval)
+
+		case <-slowTimer.C:
+			if s.isActiveSequencer() {
+				block, collectedL1Msgs, err := s.assembleBlock()
+				if err == nil {
+					s.commitBlock(block, collectedL1Msgs)
+				}
+			}
+			slowTimer.Reset(s.blockInterval)
 		}
 	}
+}
+
+// resetTimer safely stops, drains, and resets a timer.
+// t.Stop() returns false when the timer has already fired but t.C has not been
+// consumed; the non-blocking drain prevents a stale fire from triggering the
+// next select iteration.
+func resetTimer(t *time.Timer, d time.Duration) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	t.Reset(d)
 }
 
 // isActiveSequencer returns true if this node should produce the next block.
@@ -169,55 +220,77 @@ func (s *StateV2) isActiveSequencer() bool {
 	return ok
 }
 
-// produceBlock produces a new block, signs it, and either commits via Raft (HA)
-// or applies locally and sends to broadcastCh (single-node).
-func (s *StateV2) produceBlock() {
+// assembleBlock calls geth Engine API to build a candidate block from the current
+// txpool and pending L1 messages. This is a read-only operation with no side
+// effects — the result can be safely discarded if the block has no work.
+func (s *StateV2) assembleBlock() (*BlockV2, bool, error) {
 	s.mtx.RLock()
 	parentHash := s.latestBlock.Hash
 	s.mtx.RUnlock()
 
-	s.logger.Debug("Producing block", "parentHash", parentHash.Hex())
-
 	block, collectedL1Msgs, err := s.l2Node.RequestBlockDataV2(parentHash.Bytes())
 	if err != nil {
-		s.logger.Error("Failed to request block data", "error", err)
-		return
+		s.logger.Error("Failed to assemble block", "error", err)
+		return nil, false, err
 	}
-	_ = collectedL1Msgs
+	return block, collectedL1Msgs, nil
+}
 
+// commitBlock signs the assembled block and either commits via Raft (HA mode)
+// or applies locally and sends to broadcastCh (single-node mode).
+func (s *StateV2) commitBlock(block *BlockV2, collectedL1Msgs bool) {
+	t0 := time.Now()
+
+	tSign := time.Now()
 	if err := s.signBlock(block); err != nil {
 		s.logger.Error("Failed to sign block", "error", err)
 		return
 	}
+	signDur := time.Since(tSign)
 
-	if err := s.sigStore.SaveSignature(block.Hash, block.Signature); err != nil {
-		panic(fmt.Sprintf("failed to save signature at height %d: %v", block.Number, err))
-	}
-
-	// HA mode: replicate via Raft consensus (data replication + majority ACK).
-	// ha.Commit() only ensures majority of cluster nodes have received the block data.
-	// Leader applies locally after Commit. Followers apply via Raft FSM internally.
-	// Broadcast to P2P happens via ha.Subscribe() -> broadcastRoutine on all HA nodes.
 	if s.ha != nil {
+		// HA mode: replicate via Raft. FSM callback handles ApplyBlock + SaveSignature
+		// for both leader and follower. Broadcast via ha.Subscribe() -> broadcastRoutine.
+		tCommit := time.Now()
 		if err := s.ha.Commit(block); err != nil {
 			s.logger.Error("Failed to commit block via HA", "number", block.Number, "err", err)
 			return
 		}
-		s.logger.Debug("Block committed via HA", "number", block.Number, "hash", block.Hash.Hex())
-	}
+		commitDur := time.Since(tCommit)
+		totalDur := time.Since(t0)
 
-	// Apply locally (HA leader + non-HA both apply here)
-	if err := s.ApplyBlock(block); err != nil {
-		s.logger.Error("Failed to apply block", "error", err)
-		return
-	}
+		s.logger.Debug("[PERF] commitBlock",
+			"mode", "HA",
+			"height", block.Number,
+			"txCount", len(block.Transactions),
+			"gasUsed", block.GasUsed,
+			"sign_ms", float64(signDur.Microseconds())/1000.0,
+			"raft_commit_ms", float64(commitDur.Microseconds())/1000.0,
+			"total_ms", float64(totalDur.Microseconds())/1000.0,
+		)
+	} else {
+		// Non-HA mode: apply locally (includes SaveSignature), broadcast via broadcastCh.
+		tApply := time.Now()
+		if err := s.ApplyBlock(block); err != nil {
+			s.logger.Error("Failed to apply block", "error", err)
+			return
+		}
+		applyDur := time.Since(tApply)
+		totalDur := time.Since(t0)
 
-	// Non-HA: broadcast via broadcastCh -> broadcastRoutine
-	// HA: broadcast via ha.Subscribe() -> broadcastRoutine (don't write broadcastCh)
-	if s.ha == nil {
+		s.logger.Debug("[PERF] commitBlock",
+			"mode", "single",
+			"height", block.Number,
+			"txCount", len(block.Transactions),
+			"gasUsed", block.GasUsed,
+			"sign_ms", float64(signDur.Microseconds())/1000.0,
+			"apply_ms", float64(applyDur.Microseconds())/1000.0,
+			"total_ms", float64(totalDur.Microseconds())/1000.0,
+		)
+
 		select {
 		case s.broadcastCh <- block:
-			s.logger.Debug("Block produced and queued for broadcast",
+			s.logger.Debug("Block queued for broadcast",
 				"number", block.Number,
 				"hash", block.Hash.Hex(),
 				"txCount", len(block.Transactions),
@@ -244,19 +317,54 @@ func (s *StateV2) signBlock(block *BlockV2) error {
 
 // ApplyBlock applies a block to L2 and updates local state.
 // Serialized by mutex to prevent concurrent application.
-// Idempotent: silently skips blocks already applied.
+//
+// Reorg detection: when block.Number <= latestBlock.Number, we check if the
+// existing block at that height has the same hash. If yes, it's already on-chain
+// (idempotent skip). If not, it's a reorg — fall through to ApplyBlockV2 and
+// let geth handle the chain reorganization.
 func (s *StateV2) ApplyBlock(block *BlockV2) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
 	if s.latestBlock != nil && block.Number <= s.latestBlock.Number {
-		return nil // idempotent: already applied or older block
+		existing, err := s.l2Node.GetBlockByNumber(block.Number)
+		if err != nil {
+			return fmt.Errorf("ApplyBlock: GetBlockByNumber(%d): %w", block.Number, err)
+		}
+		if existing != nil && existing.Hash == block.Hash {
+			s.logger.Debug("ApplyBlock: idempotent skip", "height", block.Number)
+			return nil // already on-chain, idempotent skip
+		}
+		// Hash mismatch → reorg, fall through to ApplyBlockV2
 	}
 
+	if len(block.Signature) == 0 {
+		return fmt.Errorf("ApplyBlock: block %d missing signature", block.Number)
+	}
+
+	tGeth := time.Now()
 	if err := s.l2Node.ApplyBlockV2(block); err != nil {
 		return err
 	}
+	gethDur := time.Since(tGeth)
+
 	s.latestBlock = block
+
+	tSig := time.Now()
+	if err := s.sigStore.SaveSignature(block.Hash, block.Signature); err != nil {
+		return err
+	}
+	sigDur := time.Since(tSig)
+
+	s.logger.Debug("[PERF] ApplyBlock",
+		"height", block.Number,
+		"txCount", len(block.Transactions),
+		"gasUsed", block.GasUsed,
+		"geth_ms", float64(gethDur.Microseconds())/1000.0,
+		"sigSave_ms", float64(sigDur.Microseconds())/1000.0,
+		"total_ms", float64((gethDur+sigDur).Microseconds())/1000.0,
+	)
+
 	return nil
 }
 

--- a/sequencer/state_v2_test.go
+++ b/sequencer/state_v2_test.go
@@ -3,7 +3,6 @@ package sequencer
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/morph-l2/go-ethereum/common"
 	"github.com/tendermint/tendermint/l2node"
@@ -64,10 +63,13 @@ func newMockSequencerHA(leader bool) *mockSequencerHA {
 	}
 }
 
-func (m *mockSequencerHA) IsLeader() bool             { return m.leader }
-func (m *mockSequencerHA) Join() error                 { return nil }
-func (m *mockSequencerHA) Commit(block *BlockV2) error { return m.commitErr }
-func (m *mockSequencerHA) Subscribe() <-chan *BlockV2  { return m.subCh }
+func (m *mockSequencerHA) Start() error                          { return nil }
+func (m *mockSequencerHA) Stop()                                 {}
+func (m *mockSequencerHA) IsLeader() bool                        { return m.leader }
+func (m *mockSequencerHA) Join() error                           { return nil }
+func (m *mockSequencerHA) Commit(block *BlockV2) error           { return m.commitErr }
+func (m *mockSequencerHA) Subscribe() <-chan *BlockV2             { return m.subCh }
+func (m *mockSequencerHA) SetOnBlockApplied(fn func(*BlockV2) error) {}
 
 // newTestMockL2Node creates a mock L2Node for testing.
 func newTestMockL2Node() l2node.L2Node {
@@ -82,7 +84,7 @@ func TestStateV2_NewStateV2(t *testing.T) {
 	mockL2Node := newTestMockL2Node()
 	logger := log.NewNopLogger()
 
-	stateV2, err := NewStateV2(mockL2Node, time.Second, logger, &mockSequencerVerifier{}, nil, nil, nil)
+	stateV2, err := NewStateV2(mockL2Node, logger, &mockSequencerVerifier{}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStateV2 failed: %v", err)
 	}
@@ -95,7 +97,7 @@ func TestStateV2_LatestHeight(t *testing.T) {
 	mockL2Node := newTestMockL2Node()
 	logger := log.NewNopLogger()
 
-	stateV2, err := NewStateV2(mockL2Node, time.Second, logger, &mockSequencerVerifier{}, nil, nil, nil)
+	stateV2, err := NewStateV2(mockL2Node, logger, &mockSequencerVerifier{}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStateV2 failed: %v", err)
 	}
@@ -112,13 +114,13 @@ func TestStateV2_HasSigner_MatchesIsSequencerMode(t *testing.T) {
 	mockVerifier := &mockSequencerVerifier{}
 
 	// Without signer
-	s1, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, nil, nil, nil)
+	s1, _ := NewStateV2(mockL2Node, logger, mockVerifier, nil, nil, nil)
 	if s1.HasSigner() || s1.IsSequencerMode() {
 		t.Error("should be false when signer is nil")
 	}
 
 	// With signer
-	s2, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, &mockSignerImpl{}, nil, nil)
+	s2, _ := NewStateV2(mockL2Node, logger, mockVerifier, &mockSignerImpl{}, nil, nil)
 	if !s2.HasSigner() || !s2.IsSequencerMode() {
 		t.Error("should be true when signer is provided")
 	}
@@ -131,7 +133,7 @@ func TestStateV2_SignBlock(t *testing.T) {
 	mockSigner := &mockSignerImpl{signature: make([]byte, 65)}
 	mockVerifier := &mockSequencerVerifier{}
 
-	stateV2, err := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, nil)
+	stateV2, err := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStateV2 failed: %v", err)
 	}
@@ -153,7 +155,7 @@ func TestStateV2_SignBlockWithoutSigner(t *testing.T) {
 	mockL2Node := newTestMockL2Node()
 	logger := log.NewNopLogger()
 
-	stateV2, err := NewStateV2(mockL2Node, time.Second, logger, &mockSequencerVerifier{}, nil, nil, nil)
+	stateV2, err := NewStateV2(mockL2Node, logger, &mockSequencerVerifier{}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStateV2 failed: %v", err)
 	}
@@ -173,14 +175,14 @@ func TestNewStateV2_VerifierRequired(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	// verifier==nil should fail
-	_, err := NewStateV2(mockL2Node, time.Second, logger, nil, nil, nil, nil)
+	_, err := NewStateV2(mockL2Node, logger, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when verifier is nil")
 	}
 
 	// with signer, still fails without verifier
 	mockSigner := &mockSignerImpl{}
-	_, err = NewStateV2(mockL2Node, time.Second, logger, nil, mockSigner, nil, nil)
+	_, err = NewStateV2(mockL2Node, logger, nil, mockSigner, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when verifier is nil (with signer)")
 	}
@@ -193,7 +195,7 @@ func TestNewStateV2_WithHA(t *testing.T) {
 	mockVerifier := &mockSequencerVerifier{}
 	ha := newMockSequencerHA(true)
 
-	stateV2, err := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, ha)
+	stateV2, err := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, ha)
 	if err != nil {
 		t.Fatalf("NewStateV2 failed: %v", err)
 	}
@@ -210,14 +212,14 @@ func TestStateV2_HasSigner(t *testing.T) {
 	mockL2Node := newTestMockL2Node()
 	logger := log.NewNopLogger()
 
-	fullnode, _ := NewStateV2(mockL2Node, time.Second, logger, &mockSequencerVerifier{}, nil, nil, nil)
+	fullnode, _ := NewStateV2(mockL2Node, logger, &mockSequencerVerifier{}, nil, nil, nil)
 	if fullnode.HasSigner() {
 		t.Error("Fullnode should not have signer")
 	}
 
 	mockSigner := &mockSignerImpl{}
 	mockVerifier := &mockSequencerVerifier{}
-	seqNode, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, nil)
+	seqNode, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, nil)
 	if !seqNode.HasSigner() {
 		t.Error("Sequencer node should have signer")
 	}
@@ -230,13 +232,13 @@ func TestStateV2_IsHAMode(t *testing.T) {
 	mockVerifier := &mockSequencerVerifier{}
 
 	// Non-HA
-	nonHA, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, nil)
+	nonHA, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, nil)
 	if nonHA.IsHAMode() {
 		t.Error("IsHAMode should be false without ha")
 	}
 
 	// HA
-	ha, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, newMockSequencerHA(false))
+	ha, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, newMockSequencerHA(false))
 	if !ha.IsHAMode() {
 		t.Error("IsHAMode should be true with ha")
 	}
@@ -249,19 +251,19 @@ func TestStateV2_IsHALeader(t *testing.T) {
 	mockVerifier := &mockSequencerVerifier{}
 
 	// Non-HA: never leader
-	nonHA, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, nil)
+	nonHA, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, nil)
 	if nonHA.IsHALeader() {
 		t.Error("non-HA node should not be HA leader")
 	}
 
 	// HA follower
-	follower, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, newMockSequencerHA(false))
+	follower, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, newMockSequencerHA(false))
 	if follower.IsHALeader() {
 		t.Error("HA follower should not be leader")
 	}
 
 	// HA leader
-	leader, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, newMockSequencerHA(true))
+	leader, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, newMockSequencerHA(true))
 	if !leader.IsHALeader() {
 		t.Error("HA leader should be leader")
 	}
@@ -277,7 +279,7 @@ func TestStateV2_IsActiveSequencer_NonHA_Active(t *testing.T) {
 	mockSigner := &mockSignerImpl{address: common.HexToAddress("0x1")}
 	mockVerifier := &mockSequencerVerifier{isSequencer: true}
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, nil)
+	s, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, nil)
 	s.latestBlock = &BlockV2{Number: 0}
 
 	if !s.isActiveSequencer() {
@@ -291,7 +293,7 @@ func TestStateV2_IsActiveSequencer_NonHA_Inactive(t *testing.T) {
 	mockSigner := &mockSignerImpl{address: common.HexToAddress("0x1")}
 	mockVerifier := &mockSequencerVerifier{isSequencer: false}
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, nil)
+	s, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, nil)
 	s.latestBlock = &BlockV2{Number: 0}
 
 	if s.isActiveSequencer() {
@@ -306,7 +308,7 @@ func TestStateV2_IsActiveSequencer_HA_Leader(t *testing.T) {
 	mockVerifier := &mockSequencerVerifier{isSequencer: true}
 	ha := newMockSequencerHA(true)
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, ha)
+	s, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, ha)
 	s.latestBlock = &BlockV2{Number: 0}
 
 	if !s.isActiveSequencer() {
@@ -321,7 +323,7 @@ func TestStateV2_IsActiveSequencer_HA_Follower(t *testing.T) {
 	mockVerifier := &mockSequencerVerifier{isSequencer: true} // L1 says active
 	ha := newMockSequencerHA(false)                           // but not leader
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, ha)
+	s, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, ha)
 	s.latestBlock = &BlockV2{Number: 0}
 
 	if s.isActiveSequencer() {
@@ -335,7 +337,7 @@ func TestStateV2_IsActiveSequencer_VerifierError(t *testing.T) {
 	mockSigner := &mockSignerImpl{}
 	mockVerifier := &mockSequencerVerifier{err: errors.New("rpc error")}
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, mockVerifier, mockSigner, nil, nil)
+	s, _ := NewStateV2(mockL2Node, logger, mockVerifier, mockSigner, nil, nil)
 	s.latestBlock = &BlockV2{Number: 0}
 
 	if s.isActiveSequencer() {
@@ -351,8 +353,8 @@ func TestStateV2_ApplyBlock_Idempotent(t *testing.T) {
 	mockL2Node := newTestMockL2Node()
 	logger := log.NewNopLogger()
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, &mockSequencerVerifier{}, nil, nil, nil)
-	block := &types.BlockV2{Number: 1}
+	s, _ := NewStateV2(mockL2Node, logger, &mockSequencerVerifier{}, nil, nil, nil)
+	block := &types.BlockV2{Number: 1, Signature: []byte{0x01, 0x02, 0x03}}
 
 	// Apply twice should not error
 	if err := s.ApplyBlock(block); err != nil {
@@ -370,10 +372,10 @@ func TestStateV2_ApplyBlock_OlderBlockSkipped(t *testing.T) {
 	mockL2Node := newTestMockL2Node()
 	logger := log.NewNopLogger()
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, &mockSequencerVerifier{}, nil, nil, nil)
+	s, _ := NewStateV2(mockL2Node, logger, &mockSequencerVerifier{}, nil, nil, nil)
 
-	block2 := &types.BlockV2{Number: 2}
-	block1 := &types.BlockV2{Number: 1}
+	block2 := &types.BlockV2{Number: 2, Signature: []byte{0x01, 0x02, 0x03}}
+	block1 := &types.BlockV2{Number: 1, Signature: []byte{0x01, 0x02, 0x03}}
 
 	if err := s.ApplyBlock(block2); err != nil {
 		t.Fatalf("apply block2 failed: %v", err)
@@ -392,10 +394,10 @@ func TestStateV2_ApplyBlock_Sequential(t *testing.T) {
 	mockL2Node := newTestMockL2Node()
 	logger := log.NewNopLogger()
 
-	s, _ := NewStateV2(mockL2Node, time.Second, logger, &mockSequencerVerifier{}, nil, nil, nil)
+	s, _ := NewStateV2(mockL2Node, logger, &mockSequencerVerifier{}, nil, nil, nil)
 
 	for i := uint64(1); i <= 5; i++ {
-		block := &types.BlockV2{Number: i}
+		block := &types.BlockV2{Number: i, Signature: []byte{0x01, 0x02, 0x03}}
 		if err := s.ApplyBlock(block); err != nil {
 			t.Fatalf("apply block %d failed: %v", i, err)
 		}

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -140,6 +140,9 @@ func startNode(cfg *Config) error {
 		node.DefaultDBProvider,
 		node.DefaultMetricsProvider(tmcfg.Instrumentation),
 		nodeLogger,
+		nil, // sequencerVerifier
+		nil, // sequencerSigner
+		nil, // ha: no HA in e2e test node
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Introduce `SequencerHA` interface (`sequencer/interfaces.go`) abstracting the Raft cluster for StateV2. Methods: `Start`, `Stop`, `IsLeader`, `Join`, `Commit`, `Subscribe`, `SetOnBlockApplied`.
- Refactor StateV2 block production with a dynamic interval strategy: `fastTicker` (300ms) polls txpool via `assembleBlock` and commits immediately when transactions are found; `slowTimer` (3s) produces empty blocks as a chain-liveness fallback.
- Split `produceBlock` into `assembleBlock` (read-only block assembly, safe to call and discard) and `commitBlock` (sign + Raft commit or local apply + broadcast).
- Add HA path in `commitBlock`: leader calls `ha.Commit` for Raft replication; FSM callback handles `ApplyBlock` + `SaveSignature` for all nodes.
- `ApplyBlock`: reorg detection, idempotent skip (same block.Number + same hash), signature enforcement.
- `node/node.go`: accept `SequencerHA` parameter and inject `SetOnBlockApplied` callback.
- Remove `blockInterval` from `NewStateV2` constructor; use package-level constants `BlockInterval` (3s) and `FastBlockInterval` (300ms).

## Test plan

- [ ] `go test ./sequencer/... -v` — 37 tests pass (block_cache + state_v2)
- [ ] HA integration tests pass in docker-sequencer-test: `run-ha-test.sh test` (29/29)
- [ ] Dynamic block interval verified on devnet: empty blocks at ~3s, tx blocks at <1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)