### PR TITLE
fix(blocksync): prevent malicious peer DoS in block sync

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -46,7 +46,14 @@ const (
 	maxDiffBetweenCurrentAndReceivedBlockHeight = 100
 )
 
-var peerTimeout = 15 * time.Second // not const so we can override with tests
+var (
+	peerTimeout = 15 * time.Second // not const so we can override with tests
+
+	// peerBanDuration is how long a misbehaving peer is kept out of the pool
+	// after being detected. Declared as a variable (not const) so tests can
+	// override it.
+	peerBanDuration = 10 * time.Minute
+)
 
 /*
 	Peers self report their heights when we join the block pool.
@@ -71,6 +78,11 @@ type BlockPool struct {
 	// peers
 	peers         map[p2p.ID]*bpPeer
 	maxPeerHeight int64 // the biggest reported height
+	// peers that have been detected as misbehaving (e.g. broadcasting a
+	// decreasing height, base > height, or otherwise malformed StatusResponse).
+	// The value stores the time at which the ban expires; entries are evicted
+	// lazily by isPeerBanned. Access is guarded by mtx.
+	bannedPeers map[p2p.ID]time.Time
 
 	// atomic
 	numPending int32 // number of requests pending assignment or block response
@@ -83,7 +95,8 @@ type BlockPool struct {
 // requests and errors will be sent to requestsCh and errorsCh accordingly.
 func NewBlockPool(start int64, requestsCh chan<- BlockRequest, errorsCh chan<- peerError) *BlockPool {
 	bp := &BlockPool{
-		peers: make(map[p2p.ID]*bpPeer),
+		peers:       make(map[p2p.ID]*bpPeer),
+		bannedPeers: make(map[p2p.ID]time.Time),
 
 		requesters: make(map[int64]*bpRequester),
 		height:     start,
@@ -238,6 +251,12 @@ func (pool *BlockPool) PopRequest() {
 		}
 		delete(pool.requesters, pool.height)
 		pool.height++
+
+		// Recompute maxPeerHeight: peers whose base used to be greater than
+		// pool.height (and were therefore filtered out by updateMaxPeerHeight)
+		// may now be eligible to serve subsequent heights and contribute to
+		// maxPeerHeight. See spec-003 for details.
+		pool.updateMaxPeerHeight()
 	} else {
 		panic(fmt.Sprintf("Expected requester to pop, got nothing at height %v", pool.height))
 	}
@@ -312,23 +331,80 @@ func (pool *BlockPool) GetPeerIDs() []p2p.ID {
 }
 
 // SetPeerRange sets the peer's alleged blockchain base and height.
+//
+// It also enforces basic sanity checks against malicious or buggy peers
+// (see spec-003-blocksync-malicious-peer-fix):
+//
+//   - A peer reporting base > height is structurally impossible and is banned
+//     (CometBFT issue #5801 hardening).
+//   - An existing peer reporting a strictly lower height or base than what it
+//     reported previously is removed from the pool and banned to prevent
+//     poisoning of maxPeerHeight (CVE-2025-24371).
+//   - A peer that has been banned recently is silently ignored if it tries to
+//     re-introduce itself before its ban expires.
+//
+// In all non-malicious cases, maxPeerHeight is recomputed via
+// updateMaxPeerHeight, which filters peers whose base is above pool.height.
 func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
+	if base > height {
+		pool.Logger.Info("Peer reporting base greater than height; banning",
+			"peer", peerID, "base", base, "height", height)
+		if _, exists := pool.peers[peerID]; exists {
+			pool.removePeer(peerID)
+		}
+		pool.banPeer(peerID)
+		return
+	}
+
 	peer := pool.peers[peerID]
 	if peer != nil {
+		if height < peer.height || base < peer.base {
+			pool.Logger.Info("Peer reporting decreasing height or base; removing and banning",
+				"peer", peerID,
+				"prevHeight", peer.height, "height", height,
+				"prevBase", peer.base, "base", base)
+			pool.removePeer(peerID)
+			pool.banPeer(peerID)
+			return
+		}
 		peer.base = base
 		peer.height = height
 	} else {
+		if pool.isPeerBanned(peerID) {
+			pool.Logger.Debug("Ignoring banned peer", "peer", peerID)
+			return
+		}
 		peer = newBPPeer(pool, peerID, base, height)
 		peer.setLogger(pool.Logger.With("peer", peerID))
 		pool.peers[peerID] = peer
 	}
 
-	if height > pool.maxPeerHeight {
-		pool.maxPeerHeight = height
+	pool.updateMaxPeerHeight()
+}
+
+// banPeer marks peerID as misbehaving for peerBanDuration. Subsequent attempts
+// to introduce this peer to the pool will be ignored until the ban expires.
+// Caller must hold pool.mtx.
+func (pool *BlockPool) banPeer(peerID p2p.ID) {
+	pool.bannedPeers[peerID] = time.Now().Add(peerBanDuration)
+}
+
+// isPeerBanned reports whether peerID is currently banned. Expired entries are
+// evicted lazily so the map stays bounded under steady-state churn.
+// Caller must hold pool.mtx.
+func (pool *BlockPool) isPeerBanned(peerID p2p.ID) bool {
+	expiry, ok := pool.bannedPeers[peerID]
+	if !ok {
+		return false
 	}
+	if time.Now().Before(expiry) {
+		return true
+	}
+	delete(pool.bannedPeers, peerID)
+	return false
 }
 
 // RemovePeer removes the peer with peerID from the pool. If there's no peer
@@ -363,10 +439,30 @@ func (pool *BlockPool) removePeer(peerID p2p.ID) {
 	}
 }
 
-// If no peers are left, maxPeerHeight is set to 0.
+// updateMaxPeerHeight recomputes pool.maxPeerHeight by inspecting all current
+// peers. If no peers are left, maxPeerHeight is set to 0.
+//
+// Peers whose base is strictly greater than pool.height are excluded: such a
+// peer cannot serve the block at pool.height (the next block we need), so
+// counting it would let an attacker poison maxPeerHeight by advertising a
+// huge base/height pair, causing IsCaughtUp() to return false forever and
+// makeNextRequester() to spawn requesters that no peer can satisfy
+// (CometBFT issue #5801).
+//
+// As a safety net, when pool.height == 0 (initial state, before we have
+// requested any block) we accept all peers — at this point we don't yet
+// know which peers will be useful, and rejecting all of them would prevent
+// startup if every peer happened to have a non-zero base.
+//
+// PopRequest is responsible for calling this function after pool.height is
+// advanced, so that peers whose base now matches pool.height are
+// re-introduced into the calculation.
 func (pool *BlockPool) updateMaxPeerHeight() {
 	var max int64
 	for _, peer := range pool.peers {
+		if pool.height > 0 && peer.base > pool.height {
+			continue
+		}
 		if peer.height > max {
 			max = peer.height
 		}

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -99,10 +99,13 @@ func TestBlockPoolBasic(t *testing.T) {
 	peers.start()
 	defer peers.stop()
 
-	// Introduce each peer.
+	// Introduce each peer. We force base = start so every peer can serve from
+	// pool.height at startup; otherwise the spec-003 updateMaxPeerHeight
+	// filter (peer.base > pool.height) would exclude all of them and prevent
+	// the pool from spawning any requesters.
 	go func() {
 		for _, peer := range peers {
-			pool.SetPeerRange(peer.id, peer.base, peer.height)
+			pool.SetPeerRange(peer.id, start, peer.height)
 		}
 	}()
 
@@ -158,10 +161,13 @@ func TestBlockPoolTimeout(t *testing.T) {
 		t.Logf("Peer %v", peer.id)
 	}
 
-	// Introduce each peer.
+	// Introduce each peer. We force base = start so every peer can serve from
+	// pool.height at startup; otherwise the spec-003 updateMaxPeerHeight
+	// filter (peer.base > pool.height) would exclude all of them and prevent
+	// the pool from spawning any requesters.
 	go func() {
 		for _, peer := range peers {
-			pool.SetPeerRange(peer.id, peer.base, peer.height)
+			pool.SetPeerRange(peer.id, start, peer.height)
 		}
 	}()
 
@@ -239,4 +245,213 @@ func TestBlockPoolRemovePeer(t *testing.T) {
 	}
 
 	assert.EqualValues(t, 0, pool.MaxPeerHeight())
+}
+
+// ----------------------------------------------------------------------------
+// spec-003-blocksync-malicious-peer-fix tests
+// (CVE-2025-24371 + CometBFT issue #5801 hardening)
+// ----------------------------------------------------------------------------
+
+// TestSetPeerRange_DecreasingHeight verifies that an existing peer reporting
+// a lower height than previously is removed from the pool and banned. This
+// covers CVE-2025-24371 — without the check, an attacker could pin
+// maxPeerHeight at an unreachable value by reporting a high height first
+// and then lowering it.
+func TestSetPeerRange_DecreasingHeight(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	peerID := p2p.ID("malicious")
+	pool.SetPeerRange(peerID, 1, 1000)
+	require.EqualValues(t, 1000, pool.MaxPeerHeight())
+	require.NotNil(t, pool.peers[peerID])
+
+	pool.SetPeerRange(peerID, 1, 1)
+	require.Nil(t, pool.peers[peerID], "peer must be removed after lowering height")
+	require.True(t, pool.isPeerBanned(peerID), "peer must be banned after lowering height")
+	require.EqualValues(t, 0, pool.MaxPeerHeight(),
+		"maxPeerHeight must drop to 0 once the only peer is removed")
+}
+
+// TestSetPeerRange_DecreasingBase verifies that an existing peer reporting
+// a lower base than previously is removed and banned. Lowering base is also
+// a sign of misbehavior since a peer's archived range can only grow forward.
+func TestSetPeerRange_DecreasingBase(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(100, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	peerID := p2p.ID("malicious")
+	pool.SetPeerRange(peerID, 50, 1000)
+	require.NotNil(t, pool.peers[peerID])
+
+	pool.SetPeerRange(peerID, 10, 1000)
+	require.Nil(t, pool.peers[peerID], "peer must be removed after lowering base")
+	require.True(t, pool.isPeerBanned(peerID), "peer must be banned after lowering base")
+}
+
+// TestSetPeerRange_BaseGreaterThanHeight verifies that a peer reporting a
+// base greater than its own height (a structurally impossible state) is
+// banned immediately and never enters the pool, ensuring it cannot poison
+// maxPeerHeight (CometBFT issue #5801).
+func TestSetPeerRange_BaseGreaterThanHeight(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	peerID := p2p.ID("malicious")
+	pool.SetPeerRange(peerID, 500, 100)
+	require.Nil(t, pool.peers[peerID], "peer with base > height must not be added")
+	require.True(t, pool.isPeerBanned(peerID))
+	require.EqualValues(t, 0, pool.MaxPeerHeight())
+}
+
+// TestBanPeer_PreventsReentry verifies that a banned peer cannot reintroduce
+// itself with a fresh — even otherwise valid — StatusResponse during the
+// ban window.
+func TestBanPeer_PreventsReentry(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	peerID := p2p.ID("malicious")
+	pool.SetPeerRange(peerID, 500, 100)
+	require.True(t, pool.isPeerBanned(peerID))
+
+	pool.SetPeerRange(peerID, 1, 200)
+	require.Nil(t, pool.peers[peerID], "banned peer must not be re-added during ban window")
+	require.EqualValues(t, 0, pool.MaxPeerHeight())
+}
+
+// TestBanPeer_ExpiryAllowsReentry verifies that once the ban window expires
+// the peer can rejoin the pool normally and contributes to maxPeerHeight
+// again.
+func TestBanPeer_ExpiryAllowsReentry(t *testing.T) {
+	origDuration := peerBanDuration
+	peerBanDuration = 10 * time.Millisecond
+	t.Cleanup(func() { peerBanDuration = origDuration })
+
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	peerID := p2p.ID("rehabilitated")
+	pool.SetPeerRange(peerID, 500, 100)
+	require.True(t, pool.isPeerBanned(peerID))
+
+	time.Sleep(20 * time.Millisecond)
+
+	pool.SetPeerRange(peerID, 1, 200)
+	require.NotNil(t, pool.peers[peerID], "peer should be re-admitted after ban expiry")
+	require.False(t, pool.isPeerBanned(peerID))
+	require.EqualValues(t, 200, pool.MaxPeerHeight())
+}
+
+// TestBlockPoolMaxPeerHeightNotPoisonedByHighBase covers the core fix for
+// CometBFT issue #5801. A malicious peer broadcasting an inflated base/height
+// pair (e.g. base=1_000_000) must not raise maxPeerHeight beyond what honest
+// peers can actually serve, because that would stall IsCaughtUp() forever.
+//
+// We start the pool at the honest peer's tip so that, with the malicious
+// peer correctly filtered, IsCaughtUp can succeed. Without the fix,
+// maxPeerHeight would be ~1_000_100 and IsCaughtUp would return false
+// indefinitely.
+func TestBlockPoolMaxPeerHeightNotPoisonedByHighBase(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(200, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	pool.SetPeerRange(p2p.ID("honest"), 1, 200)
+	require.EqualValues(t, 200, pool.MaxPeerHeight())
+
+	pool.SetPeerRange(p2p.ID("malicious"), 1_000_000, 1_000_100)
+	require.EqualValues(t, 200, pool.MaxPeerHeight(),
+		"malicious peer with base above pool.height must not raise maxPeerHeight")
+
+	require.True(t, pool.IsCaughtUp(),
+		"with malicious peer filtered, the node must be able to declare itself caught up")
+}
+
+// TestBlockPoolMaxPeerHeightRefreshesOnPopRequest verifies that a peer whose
+// base is initially above pool.height — and therefore filtered out of
+// maxPeerHeight — is re-introduced once pool.height advances past its base
+// via PopRequest. This guards the segmented-peer scenario from the spec.
+func TestBlockPoolMaxPeerHeightRefreshesOnPopRequest(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(10, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	pool.SetPeerRange(p2p.ID("A"), 1, 20)
+	pool.SetPeerRange(p2p.ID("B"), 15, 100)
+	require.EqualValues(t, 20, pool.MaxPeerHeight(),
+		"peer B (base=15) must not contribute while pool.height (10) is below its base")
+
+	// Advance pool.height from 10 to 15 by installing dummy requesters and
+	// popping them. The dummy requester is never started, so Stop() is a
+	// logged no-op.
+	for h := int64(10); h < 15; h++ {
+		pool.mtx.Lock()
+		pool.requesters[h] = newBPRequester(pool, h)
+		pool.mtx.Unlock()
+		pool.PopRequest()
+	}
+
+	require.EqualValues(t, 100, pool.MaxPeerHeight(),
+		"peer B must contribute to maxPeerHeight once pool.height reaches its base")
+}
+
+// TestSegmentedPeers_BoundaryDeadlockPrevention validates the segmented
+// peer scenario from spec-003 §3.3: peer A pinned at pool.height, peer B
+// starting one block above. Without the spec-003 fix, peer B's height
+// would inflate maxPeerHeight and IsCaughtUp would block forever waiting
+// for blocks no peer can serve. With the fix, we accept a deliberate
+// liveness trade-off: peer B is filtered until pool.height advances past
+// its base, so IsCaughtUp returns true at the boundary and the node exits
+// blocksync rather than stalling.
+func TestSegmentedPeers_BoundaryDeadlockPrevention(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(150, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+	// Pretend the pool has been running for a while so IsCaughtUp's
+	// receivedBlockOrTimedOut precondition is satisfied independently of
+	// the maxPeerHeight branch we want to exercise.
+	pool.startTime = time.Now().Add(-10 * time.Second)
+
+	pool.SetPeerRange(p2p.ID("A"), 1, 150)
+	pool.SetPeerRange(p2p.ID("B"), 151, 500)
+
+	require.EqualValues(t, 150, pool.MaxPeerHeight(),
+		"peer B must be filtered while its base (151) > pool.height (150)")
+	require.True(t, pool.IsCaughtUp(),
+		"with peer B filtered, IsCaughtUp must succeed and avoid the deadlock")
+
+	// Once pool.height advances past peer B's base, peer B becomes eligible
+	// and lifts maxPeerHeight; the node correctly recognises it is no longer
+	// caught up and resumes syncing.
+	pool.mtx.Lock()
+	pool.requesters[150] = newBPRequester(pool, 150)
+	pool.mtx.Unlock()
+	pool.PopRequest()
+
+	require.EqualValues(t, 500, pool.MaxPeerHeight(),
+		"peer B must contribute to maxPeerHeight after pool.height advances to 151")
+	require.False(t, pool.IsCaughtUp(),
+		"after peer B is re-admitted, IsCaughtUp must report we still have blocks to sync")
 }


### PR DESCRIPTION
## Summary

Hardens `blocksync/BlockPool` against two related attacks where a malicious peer can stall block sync indefinitely by mis-reporting its `base`/`height` range, causing `IsCaughtUp()` to return false forever and preventing the node from switching to the consensus reactor.

- **CVE-2025-24371** — peer lowers its self-reported `height` (or `base`) → `maxPeerHeight` is pinned at an unreachable value. `SetPeerRange` now removes & bans peers reporting strictly decreasing height/base, and peers reporting `base > height` (structurally impossible).
- **CometBFT issue #5801** — peer reports a hugely inflated `base`/`height` pair (e.g. `base=1_000_000`) → `maxPeerHeight` is poisoned. `updateMaxPeerHeight` now skips peers whose `base > pool.height`; `PopRequest` re-runs it after `pool.height++` so legitimate segmented peers are re-admitted as soon as the pool catches up to their base.
- A time-bounded ban list (10 min default, var-overridable for tests) prevents banned peers from re-introducing themselves via a fresh `StatusResponse` during the ban window.

`IsCaughtUp()`, `makeNextRequester()`, and `makeRequestersRoutine()` are deliberately **unchanged** — once `maxPeerHeight` is correct, the existing logic behaves correctly.

Refs: morph-l2/morph-specs#14 (design + security analysis).
Inspired by upstream cometbft/cometbft#5803.

## Files changed

- `blocksync/pool.go` (+97 / -9): new `bannedPeers` field + `banPeer`/`isPeerBanned` helpers, hardened `SetPeerRange`, filtered `updateMaxPeerHeight`, refresh in `PopRequest`.
- `blocksync/pool_test.go` (+220 / -3): 8 new security/regression tests; `TestBlockPoolBasic`/`TestBlockPoolTimeout` updated to set `base = start` so all peers contribute to `maxPeerHeight` at startup (matching upstream cometbft/cometbft#5803).

## Test plan

- [x] `go vet ./blocksync/...` clean
- [x] `go test -count=1 ./blocksync/...` passes (only the pre-existing `TestBlockchainMessageVectors/BlockResponseMessage` failure remains — unrelated proto vector mismatch already on `main`)
- [x] `go test -race -count=1 -run 'TestSetPeerRange|TestBanPeer|TestBlockPoolMaxPeerHeight|TestSegmentedPeers' ./blocksync/...` passes (no data races)
- [x] New unit tests cover all spec §7.1 scenarios:
  - CVE-2025-24371: decreasing height, decreasing base, base > height, ban prevents re-entry, ban expiry allows re-entry
  - Issue #5801: malicious high-base peer doesn't poison `maxPeerHeight`; `maxPeerHeight` refreshes on `PopRequest` for segmented peers; segmented-peer boundary deadlock prevention
- [ ] Devnet validation per spec §7.3 (follow-up: simulate malicious peer broadcasting `base=1_000_000`, confirm node finishes blocksync within reasonable time)
- [ ] Bump `github.com/morph-l2/tendermint` replace version in `morph-l2/morph` `node/go.mod` after this PR is tagged

## Backward compatibility

No P2P message format / RPC changes; rolling upgrade safe; no state migration; zero-cost rollback (revert `node/go.mod` replace version).


Made with [Cursor](https://cursor.com)